### PR TITLE
WIP: add per-layer option to disable seeding while ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Clone Browse Server:
 ```bash
 git clone git@github.com:EOX-A/ngeo-b.git
 cd ngeo-b/
-git checkout branch-4-0
+git checkout branch-4-1
 git submodule init
 git submodule update
 ```
@@ -64,7 +64,7 @@ docker run -d -it --rm --name running-browse-server -p 8080:80 \
 In case local changes are not picked up try changing the volume mount path like below. Exec into the running container to find out the right path.
 
 ```bash
-    -v "${PWD}/ngeo_browse_server/":/usr/lib/python2.6/site-packages/ngEO_Browse_Server-4.0.2.dev-py2.6.egg/ngeo_browse_server/ \
+    -v "${PWD}/ngeo_browse_server/":/usr/lib/python2.6/site-packages/ngEO_Browse_Server-4.1.0.dev-py2.6.egg/ngeo_browse_server/ \
 ```
 
 ## Test Browse Server
@@ -134,11 +134,11 @@ cd git/ngeo-b/
 git pull
 
 # If starting a new release branch:
-git checkout -b branch-4-0
+git checkout -b branch-4-1
 vi ngeo_browse_server/__init__.py
 # Adjust version to future one
 git commit ngeo_browse_server/__init__.py -m "Adjusting version."
-git push -u origin branch-4-0
+git push -u origin branch-4-1
 
 vi ngeo_browse_server/__init__.py
 # Adjust version
@@ -155,7 +155,7 @@ git commit setup.py ngeo_browse_server/__init__.py -m "Adjusting version."
 #Development Status :: 7 - Inactive
 git push
 
-git tag -a release-4.0.0.rc.1 -m "Tagging release 4.0.0.rc.1."
+git tag -a release-4.1.0.rc.1 -m "Tagging release 4.1.0.rc.1."
 git push --tags
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ git tag -a release-4.1.0.rc.1 -m "Tagging release 4.1.0.rc.1."
 git push --tags
 ```
 
-RPMs are automatically build by travis and attached to the release.
+RPMs are automatically build by GitHub Actions and attached to the release.
 To build the packages manually run the following:
 
 ```bash

--- a/install/migration_to_4.1.0
+++ b/install/migration_to_4.1.0
@@ -35,6 +35,7 @@
 # add column disable_seeding_ingestion to table config_browselayer
 python manage.py dbshell
 ALTER TABLE "config_browselayer" ADD COLUMN "disable_seeding_ingestion" BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE "config_browselayer" ADD COLUMN "max_cached_zoom" INTEGER NULL;
 
 # restart the httpd daemon
 sudo service httpd restart

--- a/install/migration_to_4.1.0
+++ b/install/migration_to_4.1.0
@@ -1,10 +1,10 @@
 #-------------------------------------------------------------------------------
 #
 # Project: ngEO Browse Server <http://ngeo.eox.at>
-# Authors: Stephan Meissl <stephan.meissl@eox.at>
+# Authors: Lubomir Bucek <lubomir.bucek@eox.at>
 #
 #-------------------------------------------------------------------------------
-# Copyright (C) 2019 European Space Agency
+# Copyright (C) 2021 European Space Agency
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/install/migration_to_4.1.0
+++ b/install/migration_to_4.1.0
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------------------------
+#
+# Project: ngEO Browse Server <http://ngeo.eox.at>
+# Authors: Stephan Meissl <stephan.meissl@eox.at>
+#
+#-------------------------------------------------------------------------------
+# Copyright (C) 2019 European Space Agency
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Steps to migrate ngEO_Browse_Server version 4.0.2 to 4.1.0
+#-------------------------------------------------------------------------------
+# The steps assume a default installation and configuration as for
+# example provided via the `ngeo-install.sh` script.
+
+
+# add column disable_seeding_ingestion to table config_browselayer
+python manage.py dbshell
+ALTER TABLE "config_browselayer" ADD COLUMN "disable_seeding_ingestion" BOOLEAN NOT NULL DEFAULT FALSE;
+
+# restart the httpd daemon
+sudo service httpd restart

--- a/ngeo_browse_server/config/browselayer/data.py
+++ b/ngeo_browse_server/config/browselayer/data.py
@@ -33,7 +33,7 @@ class BrowseLayer(object):
                  browse_access_policy, contains_vertical_curtains,
                  shorten_ingested_interval, disable_seeding_ingestion,
                  highest_map_level,
-                 lowest_map_level, hosting_browse_server_name,
+                 lowest_map_level, max_cached_zoom, hosting_browse_server_name,
                  related_dataset_ids, description="", r_band=None, g_band=None,
                  b_band=None, radiometric_interval_min=None,
                  radiometric_interval_max=None, strategy=None,
@@ -58,6 +58,7 @@ class BrowseLayer(object):
         self._radiometric_interval_max = radiometric_interval_max
         self._highest_map_level = highest_map_level
         self._lowest_map_level = lowest_map_level
+        self._max_cached_zoom = max_cached_zoom
         self._strategy = strategy
         self._harvesting_source = harvesting_source or {}
         self._harvesting_configuration = harvesting_configuration or {}
@@ -82,6 +83,7 @@ class BrowseLayer(object):
     radiometric_interval_max = property(lambda self: self._radiometric_interval_max)
     highest_map_level = property(lambda self: self._highest_map_level)
     lowest_map_level = property(lambda self: self._lowest_map_level)
+    max_cached_zoom = property(lambda self: self._max_cached_zoom)
     strategy = property(lambda self: self._strategy)
     harvesting_source = property(lambda self: self._harvesting_source)
     harvesting_configuration = property(lambda self: self._harvesting_configuration)
@@ -107,6 +109,7 @@ class BrowseLayer(object):
             "radiometric_interval_max": self.radiometric_interval_max,
             "highest_map_level": self.highest_map_level,
             "lowest_map_level": self.lowest_map_level,
+            "max_cached_zoom": self.max_cached_zoom,
             "strategy": self.strategy,
             # TODO: fix the DB model
             "harvesting_source": "",
@@ -133,6 +136,7 @@ class BrowseLayer(object):
             radiometric_interval_max=model.radiometric_interval_max,
             highest_map_level=model.highest_map_level,
             lowest_map_level=model.lowest_map_level,
+            max_cached_zoom=model.max_cached_zoom,
             timedimension_default=model.timedimension_default,
             tile_query_limit=model.tile_query_limit
         )

--- a/ngeo_browse_server/config/browselayer/data.py
+++ b/ngeo_browse_server/config/browselayer/data.py
@@ -31,7 +31,8 @@
 class BrowseLayer(object):
     def __init__(self, browse_layer_identifier, browse_type, title, grid,
                  browse_access_policy, contains_vertical_curtains,
-                 shorten_ingested_interval, highest_map_level,
+                 shorten_ingested_interval, disable_seeding_ingestion,
+                 highest_map_level,
                  lowest_map_level, hosting_browse_server_name,
                  related_dataset_ids, description="", r_band=None, g_band=None,
                  b_band=None, radiometric_interval_min=None,
@@ -49,6 +50,7 @@ class BrowseLayer(object):
         self._related_dataset_ids = related_dataset_ids
         self._contains_vertical_curtains = contains_vertical_curtains
         self._shorten_ingested_interval = shorten_ingested_interval
+        self._disable_seeding_ingestion = disable_seeding_ingestion
         self._r_band = r_band
         self._g_band = g_band
         self._b_band = b_band
@@ -72,6 +74,7 @@ class BrowseLayer(object):
     related_dataset_ids = property(lambda self: self._related_dataset_ids)
     contains_vertical_curtains = property(lambda self: self._contains_vertical_curtains)
     shorten_ingested_interval = property(lambda self: self._shorten_ingested_interval)
+    disable_seeding_ingestion = property(lambda self: self._disable_seeding_ingestion)
     r_band = property(lambda self: self._r_band)
     g_band = property(lambda self: self._g_band)
     b_band = property(lambda self: self._b_band)
@@ -96,6 +99,7 @@ class BrowseLayer(object):
             "browse_access_policy": self.browse_access_policy,
             "contains_vertical_curtains": self.contains_vertical_curtains,
             "shorten_ingested_interval": self.shorten_ingested_interval,
+            "disable_seeding_ingestion": self.disable_seeding_ingestion,
             "r_band": self.r_band,
             "g_band": self.g_band,
             "b_band": self.b_band,
@@ -123,6 +127,7 @@ class BrowseLayer(object):
                                  for rel_ds in model.related_datasets.all()],
             contains_vertical_curtains=model.contains_vertical_curtains,
             shorten_ingested_interval=model.shorten_ingested_interval,
+            disable_seeding_ingestion=model.disable_seeding_ingestion,
             r_band=model.r_band, g_band=model.g_band, b_band=model.b_band,
             radiometric_interval_min=model.radiometric_interval_min,
             radiometric_interval_max=model.radiometric_interval_max,

--- a/ngeo_browse_server/config/browselayer/data.py
+++ b/ngeo_browse_server/config/browselayer/data.py
@@ -140,3 +140,9 @@ class BrowseLayer(object):
             timedimension_default=model.timedimension_default,
             tile_query_limit=model.tile_query_limit
         )
+
+
+def get_layer_max_cached_zoom(bl):
+    if bl.max_cached_zoom is not None:
+        return bl.max_cached_zoom
+    return bl.highest_map_level

--- a/ngeo_browse_server/config/browselayer/decoding.py
+++ b/ngeo_browse_server/config/browselayer/decoding.py
@@ -94,7 +94,7 @@ def decode_browse_layers(browse_layers_elem, config=None):
             browse_layer_elem.findtext(ns_cfg("tileQueryLimit"))
             or tile_query_limit_default
         )
-
+        disableSeedingIngestion = True if (browse_layer_elem.find(ns_cfg("disableSeedingIngestion")) is not None and browse_layer_elem.find(ns_cfg("disableSeedingIngestion")).text == "true") else False
         browse_layers.append(BrowseLayer(
             browse_layer_elem.get("browseLayerId"),
             browse_layer_elem.find(ns_cfg("browseType")).text,
@@ -103,6 +103,7 @@ def decode_browse_layers(browse_layers_elem, config=None):
             browse_layer_elem.find(ns_cfg("browseAccessPolicy")).text,
             browse_layer_elem.find(ns_cfg("containsVerticalCurtains")).text == "true",
             float(browse_layer_elem.find(ns_cfg("shortenIngestedInterval")).text),
+            disableSeedingIngestion,
             int(browse_layer_elem.find(ns_cfg("highestMapLevel")).text),
             int(browse_layer_elem.find(ns_cfg("lowestMapLevel")).text),
             browse_layer_elem.find(ns_cfg("hostingBrowseServerName")).text,
@@ -122,6 +123,7 @@ browse_layer_decoder = XMLDecoder({
     "related_dataset_ids": ("cfg:relatedDatasetIds/cfg:datasetId/text()", str, "*"),
     "contains_vertical_curtains": ("cfg:containsVerticalCurtains", lambda v: v == "true"),
     "shorten_ingested_interval": ("cfg:shortenIngestedInterval/text()", (float, int)),  # tuple, so that 0 or 100 is still parsed
+    "disable_seeding_ingestion": ("cfg:disableSeedingIngestion", lambda v: v == "true"),
     "r_band": ("cfg:rgbBands/text()", lambda v: int(v.split(",")[0])),
     "g_band": ("cfg:rgbBands/text()", lambda v: int(v.split(",")[1])),
     "b_band": ("cfg:rgbBands/text()", lambda v: int(v.split(",")[2])),

--- a/ngeo_browse_server/config/browselayer/decoding.py
+++ b/ngeo_browse_server/config/browselayer/decoding.py
@@ -95,6 +95,9 @@ def decode_browse_layers(browse_layers_elem, config=None):
             or tile_query_limit_default
         )
         disableSeedingIngestion = True if (browse_layer_elem.find(ns_cfg("disableSeedingIngestion")) is not None and browse_layer_elem.find(ns_cfg("disableSeedingIngestion")).text == "true") else False
+        # if maxCachedZoom not present, set it as highestMapLevel which is mandatory
+        maxCachedZoom = browse_layer_elem.findtext(ns_cfg("maxCachedZoom"),
+            default=browse_layer_elem.findtext(ns_cfg("highestMapLevel")))
         browse_layers.append(BrowseLayer(
             browse_layer_elem.get("browseLayerId"),
             browse_layer_elem.find(ns_cfg("browseType")).text,
@@ -106,6 +109,7 @@ def decode_browse_layers(browse_layers_elem, config=None):
             disableSeedingIngestion,
             int(browse_layer_elem.find(ns_cfg("highestMapLevel")).text),
             int(browse_layer_elem.find(ns_cfg("lowestMapLevel")).text),
+            int(maxCachedZoom),
             browse_layer_elem.find(ns_cfg("hostingBrowseServerName")).text,
             related_dataset_ids,
             **opt

--- a/ngeo_browse_server/config/browselayer/serialization.py
+++ b/ngeo_browse_server/config/browselayer/serialization.py
@@ -32,6 +32,7 @@ from cStringIO import StringIO
 from lxml.etree import Element, SubElement, ElementTree
 
 from ngeo_browse_server.namespace import ns_cfg
+from ngeo_browse_server.config.browselayer.data import get_layer_max_cached_zoom
 
 
 def serialize_browse_layers(browse_layers, stream=None, pretty_print=False):
@@ -75,7 +76,7 @@ def serialize_browse_layers(browse_layers, stream=None, pretty_print=False):
         
         SubElement(bl_elem, ns_cfg("highestMapLevel")).text = str(browse_layer.highest_map_level)
         SubElement(bl_elem, ns_cfg("lowestMapLevel")).text = str(browse_layer.lowest_map_level)
-        SubElement(bl_elem, ns_cfg("maxCachedZoom")).text = str(browse_layer.max_cached_zoom)
+        SubElement(bl_elem, ns_cfg("maxCachedZoom")).text = str(get_layer_max_cached_zoom(browse_layer))
         SubElement(bl_elem, ns_cfg("timeDimensionDefault")).text = str(browse_layer.timedimension_default)
         SubElement(bl_elem, ns_cfg("tileQueryLimit")).text = str(browse_layer.tile_query_limit)
     

--- a/ngeo_browse_server/config/browselayer/serialization.py
+++ b/ngeo_browse_server/config/browselayer/serialization.py
@@ -75,6 +75,7 @@ def serialize_browse_layers(browse_layers, stream=None, pretty_print=False):
         
         SubElement(bl_elem, ns_cfg("highestMapLevel")).text = str(browse_layer.highest_map_level)
         SubElement(bl_elem, ns_cfg("lowestMapLevel")).text = str(browse_layer.lowest_map_level)
+        SubElement(bl_elem, ns_cfg("maxCachedZoom")).text = str(browse_layer.max_cached_zoom)
         SubElement(bl_elem, ns_cfg("timeDimensionDefault")).text = str(browse_layer.timedimension_default)
         SubElement(bl_elem, ns_cfg("tileQueryLimit")).text = str(browse_layer.tile_query_limit)
     

--- a/ngeo_browse_server/config/browselayer/serialization.py
+++ b/ngeo_browse_server/config/browselayer/serialization.py
@@ -64,6 +64,7 @@ def serialize_browse_layers(browse_layers, stream=None, pretty_print=False):
             SubElement(rel_ds_elem, ns_cfg("datasetId")).text = rel_ds_id
         SubElement(bl_elem, ns_cfg("containsVerticalCurtains")).text = "true" if browse_layer.contains_vertical_curtains else "false"
         SubElement(bl_elem, ns_cfg("shortenIngestedInterval")).text = str(browse_layer.shorten_ingested_interval)
+        SubElement(bl_elem, ns_cfg("disableSeedingIngestion")).text = "true" if browse_layer.disable_seeding_ingestion else "false"
         if has_rgb:
             SubElement(bl_elem, ns_cfg("rgbBands")).text = ",".join(map(str, rgb))
         

--- a/ngeo_browse_server/config/models.py
+++ b/ngeo_browse_server/config/models.py
@@ -80,6 +80,7 @@ class BrowseLayer(models.Model):
     )
     contains_vertical_curtains = models.BooleanField(default=False) # TODO: Fixed to False as vertical curtains are not supported for now.
     shorten_ingested_interval = models.FloatField(default=0.0, validators=[MaxValueValidator(float(100.0)), MinValueValidator(float(0.0))])
+    disable_seeding_ingestion = models.BooleanField(default=False)
     r_band = models.IntegerField(null=True, blank=True, default=None)
     g_band = models.IntegerField(null=True, blank=True, default=None)
     b_band = models.IntegerField(null=True, blank=True, default=None)

--- a/ngeo_browse_server/config/models.py
+++ b/ngeo_browse_server/config/models.py
@@ -94,6 +94,7 @@ class BrowseLayer(models.Model):
     )
     highest_map_level = models.IntegerField(null=True, blank=True, default=None)
     lowest_map_level = models.IntegerField(null=True, blank=True, default=None)
+    max_cached_zoom = models.IntegerField(null=True, blank=True, default=None)
 
     # ingestion strategy
     strategy = models.CharField(max_length=8, default="inherit",
@@ -127,7 +128,10 @@ class BrowseLayer(models.Model):
         # custom model validation
         if self.highest_map_level < self.lowest_map_level:
             raise ValidationError("Highest map level number must be greater "
-                                  "than lowest map level number.")
+                                  "than or equal to lowest map level number.")
+        if self.max_cached_zoom < self.highest_map_level:
+            raise ValidationError("Max cached zoom number must be greater "
+                                  "than or equal to highest map level number.")
         # TODO: more checks
 
 

--- a/ngeo_browse_server/control/ingest/__init__.py
+++ b/ngeo_browse_server/control/ingest/__init__.py
@@ -223,26 +223,26 @@ def ingest_browse_report(parsed_browse_report, do_preprocessing=True, config=Non
                     transaction.commit(using="mapcache")
 
                     logger.info("Committed changes to database.")
+                    if browse_layer.disable_seeding_ingestion is not True:
+                        for minx, miny, maxx, maxy, start_time, end_time in seed_areas:
+                            try:
 
-                    for minx, miny, maxx, maxy, start_time, end_time in seed_areas:
-                        try:
+                                # seed MapCache synchronously
+                                # TODO: maybe replace this with an async solution
+                                seed_mapcache(tileset=browse_layer.id,
+                                              grid=browse_layer.grid,
+                                              minx=minx, miny=miny,
+                                              maxx=maxx, maxy=maxy,
+                                              minzoom=browse_layer.lowest_map_level,
+                                              maxzoom=browse_layer.highest_map_level,
+                                              start_time=start_time,
+                                              end_time=end_time,
+                                              delete=False,
+                                              **get_mapcache_seed_config(config))
+                                logger.info("Successfully finished seeding.")
 
-                            # seed MapCache synchronously
-                            # TODO: maybe replace this with an async solution
-                            seed_mapcache(tileset=browse_layer.id,
-                                          grid=browse_layer.grid,
-                                          minx=minx, miny=miny,
-                                          maxx=maxx, maxy=maxy,
-                                          minzoom=browse_layer.lowest_map_level,
-                                          maxzoom=browse_layer.highest_map_level,
-                                          start_time=start_time,
-                                          end_time=end_time,
-                                          delete=False,
-                                          **get_mapcache_seed_config(config))
-                            logger.info("Successfully finished seeding.")
-
-                        except Exception, e:
-                            logger.warn("Seeding failed: %s" % str(e))
+                            except Exception, e:
+                                logger.warn("Seeding failed: %s" % str(e))
 
                     # log ingestions for report generation
                     # date/browseType/browseLayerId/start/end

--- a/ngeo_browse_server/control/management/commands/ngeo_export.py
+++ b/ngeo_browse_server/control/management/commands/ngeo_export.py
@@ -43,7 +43,7 @@ from ngeo_browse_server.config.models import (
 )
 from ngeo_browse_server.config.browsereport import data as browsereport_data
 from ngeo_browse_server.config.browsereport.serialization import serialize_browse_report
-from ngeo_browse_server.config.browselayer import data as browselayer_data
+from ngeo_browse_server.config.browselayer.data import get_layer_max_cached_zoom, BrowseLayer as BL
 from ngeo_browse_server.config.browselayer.serialization import serialize_browse_layers
 from ngeo_browse_server.control.migration import package
 from ngeo_browse_server.mapcache import tileset
@@ -159,7 +159,7 @@ class Command(LogToConsoleMixIn, BaseCommand):
                     raise CommandError("Browse layer with browse type '%s' does "
                                        "not exist" % browse_type)
             
-            browse_layer = browselayer_data.BrowseLayer.from_model(browse_layer_model)
+            browse_layer = BL.from_model(browse_layer_model)
             p.set_browse_layer(
                 serialize_browse_layers((browse_layer,), pretty_print=True)
             )
@@ -205,7 +205,6 @@ class Command(LogToConsoleMixIn, BaseCommand):
                     # set the 
                     base_filename = browse_model.coverage_id
                     data_filename = base_filename + ".tif"
-                    md_filename = base_filename + ".xml"
                     footprint_filename = base_filename + ".wkb"
                     
                     browse._file_name = data_filename
@@ -250,10 +249,10 @@ class Command(LogToConsoleMixIn, BaseCommand):
                         )
                         
                         for tile_desc in ts.get_tiles(
-                            browse_layer.id, 
+                            browse_layer.id,
                             URN_TO_GRID[browse_layer.grid], dim=dim,
                             minzoom=browse_layer.lowest_map_level,
-                            maxzoom=browse_layer.max_cached_zoom
+                            maxzoom=get_layer_max_cached_zoom(browse_layer),
                         ):
                             p.add_cache_file(*tile_desc)
                             

--- a/ngeo_browse_server/control/management/commands/ngeo_export.py
+++ b/ngeo_browse_server/control/management/commands/ngeo_export.py
@@ -252,8 +252,8 @@ class Command(LogToConsoleMixIn, BaseCommand):
                         for tile_desc in ts.get_tiles(
                             browse_layer.id, 
                             URN_TO_GRID[browse_layer.grid], dim=dim,
-                            minzoom=browse_layer.highest_map_level,
-                            maxzoom=browse_layer.lowest_map_level
+                            minzoom=browse_layer.lowest_map_level,
+                            maxzoom=browse_layer.max_cached_zoom
                         ):
                             p.add_cache_file(*tile_desc)
                             

--- a/ngeo_browse_server/control/queries.py
+++ b/ngeo_browse_server/control/queries.py
@@ -240,7 +240,7 @@ def create_browse(browse, browse_report_model, browse_layer_model, coverage_id,
                           minx=time_model.minx, miny=time_model.miny,
                           maxx=time_model.maxx, maxy=time_model.maxy,
                           minzoom=browse_layer_model.lowest_map_level,
-                          maxzoom=browse_layer_model.highest_map_level,
+                          maxzoom=browse_layer_model.max_cached_zoom,
                           start_time=time_model.start_time,
                           end_time=time_model.end_time,
                           delete=True,
@@ -344,7 +344,7 @@ def remove_browse(browse_model, browse_layer_model, coverage_id,
                           minx=time_model.minx, miny=time_model.miny,
                           maxx=time_model.maxx, maxy=time_model.maxy,
                           minzoom=browse_layer_model.lowest_map_level,
-                          maxzoom=browse_layer_model.highest_map_level,
+                          maxzoom=browse_layer_model.max_cached_zoom,
                           start_time=time_model.start_time,
                           end_time=time_model.end_time,
                           delete=True,
@@ -589,14 +589,14 @@ def update_browse_layer(browse_layer, config=None):
     mutable_values = [
         "title", "description", "browse_access_policy",
         "timedimension_default", "tile_query_limit", "strategy",
-        "disable_seeding_ingestion",
+        "disable_seeding_ingestion", "max_cached_zoom",
     ]
 
     refresh_mapcache_xml = False
     refresh_metadata = False
     for key in mutable_values:
         setattr(browse_layer_model, key, getattr(browse_layer, key))
-        if key in ("timedimension_default", "tile_query_limit", "disable_seeding_ingestion",):
+        if key in ("timedimension_default", "tile_query_limit", "disable_seeding_ingestion", "max_cached_zoom"):
             refresh_mapcache_xml = True
         if key in ("title", "description"):
             refresh_metadata = True

--- a/ngeo_browse_server/control/queries.py
+++ b/ngeo_browse_server/control/queries.py
@@ -46,6 +46,7 @@ from eoxserver.core.util.timetools import isotime
 from ngeo_browse_server.config import (
     models, get_ngeo_config, get_project_relative_path
 )
+from ngeo_browse_server.config.browselayer.data import get_layer_max_cached_zoom
 from ngeo_browse_server.mapcache import models as mapcache_models
 from ngeo_browse_server.mapcache.tasks import (
     seed_mapcache, add_mapcache_layer_xml, remove_mapcache_layer_xml
@@ -240,7 +241,7 @@ def create_browse(browse, browse_report_model, browse_layer_model, coverage_id,
                           minx=time_model.minx, miny=time_model.miny,
                           maxx=time_model.maxx, maxy=time_model.maxy,
                           minzoom=browse_layer_model.lowest_map_level,
-                          maxzoom=browse_layer_model.max_cached_zoom,
+                          maxzoom=get_layer_max_cached_zoom(browse_layer_model),
                           start_time=time_model.start_time,
                           end_time=time_model.end_time,
                           delete=True,
@@ -344,7 +345,7 @@ def remove_browse(browse_model, browse_layer_model, coverage_id,
                           minx=time_model.minx, miny=time_model.miny,
                           maxx=time_model.maxx, maxy=time_model.maxy,
                           minzoom=browse_layer_model.lowest_map_level,
-                          maxzoom=browse_layer_model.max_cached_zoom,
+                          maxzoom=get_layer_max_cached_zoom(browse_layer_model),
                           start_time=time_model.start_time,
                           end_time=time_model.end_time,
                           delete=True,

--- a/ngeo_browse_server/control/queries.py
+++ b/ngeo_browse_server/control/queries.py
@@ -588,14 +588,15 @@ def update_browse_layer(browse_layer, config=None):
 
     mutable_values = [
         "title", "description", "browse_access_policy",
-        "timedimension_default", "tile_query_limit", "strategy"
+        "timedimension_default", "tile_query_limit", "strategy",
+        "disable_seeding_ingestion",
     ]
 
     refresh_mapcache_xml = False
     refresh_metadata = False
     for key in mutable_values:
         setattr(browse_layer_model, key, getattr(browse_layer, key))
-        if key in ("timedimension_default", "tile_query_limit"):
+        if key in ("timedimension_default", "tile_query_limit", "disable_seeding_ingestion",):
             refresh_mapcache_xml = True
         if key in ("title", "description"):
             refresh_metadata = True

--- a/ngeo_browse_server/control/templates/test_control/mapcache.xml
+++ b/ngeo_browse_server/control/templates/test_control/mapcache.xml
@@ -35,9 +35,9 @@
         <source>{{ layer.pk }}</source>
         <cache>{{ layer.pk }}</cache>
         {% if layer.grid == "urn:ogc:def:wkss:OGC:1.0:GoogleCRS84Quad" %}
-        <grid max-cached-zoom="{{ layer.highest_map_level }}" out-of-zoom-strategy="reassemble">WGS84</grid>
+        <grid max-cached-zoom="{{ layer.max_cached_zoom }}" out-of-zoom-strategy="reassemble">WGS84</grid>
         {% elif layer.grid == "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible" %}
-        <grid max-cached-zoom="{{ layer.highest_map_level }}" out-of-zoom-strategy="reassemble">GoogleMapsCompatible</grid>
+        <grid max-cached-zoom="{{ layer.max_cached_zoom }}" out-of-zoom-strategy="reassemble">GoogleMapsCompatible</grid>
         {% endif %}
         <format>mixed</format>
         <metatile>{% if layer.disable_seeding_ingestion %}1 1{% else %}8 8{% endif %}

--- a/ngeo_browse_server/control/templates/test_control/mapcache.xml
+++ b/ngeo_browse_server/control/templates/test_control/mapcache.xml
@@ -40,9 +40,10 @@
         <grid max-cached-zoom="{{ layer.highest_map_level }}" out-of-zoom-strategy="reassemble">GoogleMapsCompatible</grid>
         {% endif %}
         <format>mixed</format>
-        <metatile>8 8</metatile>
+        <metatile>{% if layer.disable_seeding_ingestion %}1 1{% else %}8 8{% endif %}
+        </metatile>
         <expires>3600</expires>
-        <read-only>true</read-only>
+        <read-only>{% if layer.disable_seeding_ingestion %}false{% else %}true{% endif %}</read-only>
         <timedimension type="sqlite" default="2010">
             <dbfile>{{ mapcache_test_db }}</dbfile>
             {% if layer.grid == "urn:ogc:def:wkss:OGC:1.0:GoogleCRS84Quad" %}

--- a/ngeo_browse_server/control/templates/test_control/mapcache.xml
+++ b/ngeo_browse_server/control/templates/test_control/mapcache.xml
@@ -35,9 +35,9 @@
         <source>{{ layer.pk }}</source>
         <cache>{{ layer.pk }}</cache>
         {% if layer.grid == "urn:ogc:def:wkss:OGC:1.0:GoogleCRS84Quad" %}
-        <grid max-cached-zoom="{{ layer.max_cached_zoom }}" out-of-zoom-strategy="reassemble">WGS84</grid>
+        <grid max-cached-zoom="{% if layer.max_cached_zoom != None %}{{ layer.max_cached_zoom }}{% else %}{{ layer.highest_map_level }}{% endif %}" out-of-zoom-strategy="reassemble">WGS84</grid>
         {% elif layer.grid == "urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible" %}
-        <grid max-cached-zoom="{{ layer.max_cached_zoom }}" out-of-zoom-strategy="reassemble">GoogleMapsCompatible</grid>
+        <grid max-cached-zoom="{% if layer.max_cached_zoom != None %}{{ layer.max_cached_zoom }}{% else %}{{ layer.highest_map_level }}{% endif %}" out-of-zoom-strategy="reassemble">GoogleMapsCompatible</grid>
         {% endif %}
         <format>mixed</format>
         <metatile>{% if layer.disable_seeding_ingestion %}1 1{% else %}8 8{% endif %}

--- a/ngeo_browse_server/mapcache/tasks.py
+++ b/ngeo_browse_server/mapcache/tasks.py
@@ -40,6 +40,8 @@ from django.core.urlresolvers import reverse
 from ngeo_browse_server.config import (
     get_ngeo_config, get_project_relative_path, safe_get
 )
+from ngeo_browse_server.config.browselayer.data import get_layer_max_cached_zoom
+
 from ngeo_browse_server.lock import (FileLock, LockException)
 from ngeo_browse_server.mapcache.exceptions import (
     SeedException, LayerException
@@ -261,7 +263,7 @@ def add_mapcache_layer_xml(browse_layer, config=None):
             E("cache", name),
             E("grid",
                 URN_TO_GRID[browse_layer.grid], **{
-                    "max-cached-zoom": str(browse_layer.max_cached_zoom),
+                    "max-cached-zoom": str(get_layer_max_cached_zoom(browse_layer)),
                     "out-of-zoom-strategy": "reassemble"
                 }
             ),

--- a/ngeo_browse_server/mapcache/tasks.py
+++ b/ngeo_browse_server/mapcache/tasks.py
@@ -261,7 +261,7 @@ def add_mapcache_layer_xml(browse_layer, config=None):
             E("cache", name),
             E("grid",
                 URN_TO_GRID[browse_layer.grid], **{
-                    "max-cached-zoom": str(browse_layer.highest_map_level),
+                    "max-cached-zoom": str(browse_layer.max_cached_zoom),
                     "out-of-zoom-strategy": "reassemble"
                 }
             ),

--- a/ngeo_browse_server/mapcache/tasks.py
+++ b/ngeo_browse_server/mapcache/tasks.py
@@ -266,9 +266,11 @@ def add_mapcache_layer_xml(browse_layer, config=None):
                 }
             ),
             E("format", "mixed"),
-            E("metatile", "8 8"),
+            E("metatile", "1 1" if browse_layer.disable_seeding_ingestion
+                else "8 8"),
             E("expires", "3600"),
-            E("read-only", "true"),
+            E("read-only", "false" if browse_layer.disable_seeding_ingestion
+                else "true"),
             E("timedimension",
                 E("dbfile", settings.DATABASES["mapcache"]["NAME"]),
                 E("query", "select * from (select strftime('%Y-%m-%dT%H:%M:%SZ',start_time)||'/'||strftime('%Y-%m-%dT%H:%M:%SZ',end_time) as interval from time where source_id=:tileset and (start_time<datetime(:end_timestamp,'unixepoch') and (end_time>datetime(:start_timestamp,'unixepoch')) or (start_time=end_time and start_time<datetime(:end_timestamp,'unixepoch') and end_time>=datetime(:start_timestamp,'unixepoch'))) and ((maxx>=:minx and minx<=:maxx) or (maxx>"+str(bounds[2])+" and (maxx-"+str(full)+")>=:minx and (minx-"+str(full)+")<=:maxx)) and maxy>=:miny and miny<=:maxy order by end_time desc limit "+str(browse_layer.tile_query_limit)+") order by interval asc"),

--- a/ngeo_browse_server/mapcache/tileset.py
+++ b/ngeo_browse_server/mapcache/tileset.py
@@ -123,10 +123,10 @@ class SQLiteSchemaTileSet(object):
             ]
             
             if minzoom is not None:
-                where_clauses.append("tiles.z <= %d" % minzoom)
+                where_clauses.append("tiles.z >= %d" % minzoom)
             
             if maxzoom is not None:
-                where_clauses.append("tiles.z >= %d" % maxzoom)
+                where_clauses.append("tiles.z <= %d" % maxzoom)
                 
             if dim:
                 where_clauses.append("tiles.dim = '%s'" % dim)

--- a/schemas/ConfigurationElements.xsd
+++ b/schemas/ConfigurationElements.xsd
@@ -639,7 +639,13 @@ Mapped to the Abstract property for this layer in the  capability file.</documen
           <documentation>A shorter time interval than provided by start and end times shall be used during ingestion. Expects a float value in the range [0.0, 100.0] configuring the percentage the interval shall be shortened. If set to 100%, time in the middle is used for both start and end. Default is 0 resulting in usage of the unchanged time interval.
           </documentation>
         </annotation>
-      </element>      
+      </element>
+      <element name="disableSeedingIngestion" type="boolean">
+        <annotation>
+          <documentation>If set to true, ingestion will not trigger an immediate seeding and mapcache tiles will not be set to read-only. Default is false.
+          </documentation>
+        </annotation>
+      </element>
       <element name="rgbBands" type="cfg:string255" minOccurs="0">
         <annotation>
           <documentation>Bands to select from the browse image file for Red, Green, Blue in the WMS response. This is a a comma-separated list of three integers (e.g. 4 2 3). If not present, the default is to use  the first three bands (1 2 3).</documentation>

--- a/schemas/examples/browseLayers.xml
+++ b/schemas/examples/browseLayers.xml
@@ -9,7 +9,8 @@
             <cfg:datasetId>SAR</cfg:datasetId>
         </cfg:relatedDatasetIds>
         <cfg:containsVerticalCurtains>false</cfg:containsVerticalCurtains>
-        <cfg:shortenIngestedInterval>0.0</cfg:shortenIngestedIntervalPercent>        
+        <cfg:shortenIngestedInterval>0.0</cfg:shortenIngestedIntervalPercent>
+        <cfg:disableSeedingIngestion>false</cfg:disableSeedingIngestion>
         <cfg:rgbBands>1,2,3</cfg:rgbBands>
         <cfg:radiometricInterval>
             <cfg:min>0</cfg:min>


### PR DESCRIPTION
- adds per-layer option `disableSeedingIngestion` (default false) to perform ingestion without seeding, this configuration sets `read_only` of a tileset to `false` and `metatiling` to `1 1` closes #46 
- adds per-layer option `maxCacheZoom` by default equal to `highestMapLevel` which allows to request tiles from zooms equal to `maxCacheZoom` - that means possibly higher than `highestMapLevel` (which will still be used for manual or ingestion induced seeding)
- adds `ngeo_sync_mapcache_db` command to re-generate the MapCache SQLite DB